### PR TITLE
Allow disabling sudo on Linux

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -119,3 +119,54 @@ jobs:
 
     - name: test CS
       run: /opt/racketcs/bin/racket -e '(displayln 42)'
+
+  run_sudo:
+    name: "Install as root and user"
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+
+    - name: Set Node.js 10.x
+      uses: actions/setup-node@master
+      with:
+        node-version: 10.x
+
+    - name: npm install
+      run: npm install
+
+    - name: npm build
+      run: npm build
+
+    - name: install non-sudo version
+      run: node lib/setup-racket.js
+      env:
+        INPUT_VARIANT: 'CS'
+        INPUT_VERSION: '7.9'
+        INPUT_DEST: '${HOME}/racket-user'
+        INPUT_SUDO: never
+
+    - name: install sudo version
+      run: node lib/setup-racket.js
+      env:
+        INPUT_VARIANT: 'CS'
+        INPUT_VERSION: '7.9'
+        INPUT_DEST: '/opt/racket-root'
+        INPUT_SUDO: always
+
+    - name: test Racket
+      run: |
+        ${HOME}/racket-user/bin/racket -ve- '(displayln 42)'
+        /opt/racket-root/bin/racket -ve- '(displayln 42)'
+
+    - name: test user packages
+      run: '${HOME}/racket-user/bin/raco pkg install -i --skip-installed --no-docs --auto racket-test-core'
+
+    - name: test root packages
+      id: rootpkg
+      run: '/opt/racket-root/bin/raco pkg install -i --skip-installed --no-docs --auto racket-test-core'
+      continue-on-error: true
+
+    - name: check that racket-root is installed as root
+      if: ${{ always() && steps.rootpkg.outcome != 'failure' }}
+      run: exit 1

--- a/README.md
+++ b/README.md
@@ -55,6 +55,23 @@ steps:
 - run: racket hello.rkt
 ```
 
+Disable sudo (only on Linux; the default is to use `sudo`
+if the command exists):
+
+```yaml
+steps:
+- uses: actions/checkout@master
+- uses: Bogdanp/setup-racket@v0.13
+  with:
+    architecture: 'x64'
+    distribution: 'full'
+    variant: 'CS'
+    version: '8.0'
+    dest: '${HOME}/racket'
+    sudo: never            # one of always or never
+- run: ${HOME}/racket/bin/racket hello.rkt
+```
+
 Matrix Testing:
 
 ```yaml

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,12 @@ inputs:
   packages:
     description: 'A comma-separated list of packages to install from the Package Catalog.'
     default: ''
+  dest:
+    description: 'Installation destination. Linux only.'
+    default: ''
+  sudo:
+    description: 'Use sudo or not (always, never).'
+    default: ''
 runs:
   using: 'node12'
   main: 'lib/setup-racket.js'

--- a/lib/common.js
+++ b/lib/common.js
@@ -81,7 +81,7 @@ ln -s /Applications/Racket/bin/raco /usr/local/bin/raco
 }
 // This detects whether or not sudo is present in case we're in a
 // Docker container.  See issue #2.
-function installLinux(path, dest) {
+function installLinux(path, dest, useSudo) {
     return __awaiter(this, void 0, void 0, function* () {
         let script;
         if (dest) {
@@ -91,13 +91,22 @@ function installLinux(path, dest) {
             script = `echo "yes\n1\n" | sh ${path} --create-dir --unix-style --dest /usr/`;
         }
         yield fs.promises.writeFile('/tmp/install-racket.impl.sh', script);
-        yield fs.promises.writeFile('/tmp/install-racket.sh', `
+        let launchScript = 'sh /tmp/install-racket.impl.sh';
+        if (useSudo == 'always') {
+            yield fs.promises.writeFile('/tmp/install-racket.sh', `sudo ${launchScript}\n`);
+        }
+        else if (useSudo == 'never') {
+            yield fs.promises.writeFile('/tmp/install-racket.sh', `${launchScript}\n`);
+        }
+        else {
+            yield fs.promises.writeFile('/tmp/install-racket.sh', `
 if command -v sudo; then
-  sudo sh /tmp/install-racket.impl.sh
+  sudo ${launchScript}
 else
-  sh /tmp/install-racket.impl.sh
+  ${launchScript}
 fi
 `);
+        }
         yield exec.exec('sh', ['/tmp/install-racket.sh']);
     });
 }
@@ -164,14 +173,14 @@ Install-ChocolateyPackage @packageArgs
         core.addPath(racketPath);
     });
 }
-function install(version, arch, distribution, variant, dest) {
+function install(version, arch, distribution, variant, dest, useSudo) {
     return __awaiter(this, void 0, void 0, function* () {
         const path = yield tc.downloadTool(makeInstallerURL(version, arch, distribution, variant, process.platform));
         switch (process.platform) {
             case 'darwin':
                 return yield installDarwin(path);
             case 'linux':
-                return yield installLinux(path, dest);
+                return yield installLinux(path, dest, useSudo);
             case 'win32':
                 return yield installWin32(version, arch, path);
             default:
@@ -213,6 +222,13 @@ function parseDistribution(s) {
     return s;
 }
 exports.parseDistribution = parseDistribution;
+function parseUseSudo(s) {
+    if (s !== '' && s !== 'always' && s !== 'never') {
+        throw new Error(`invalid sudo '${s}'\n  must be one of: 'always', 'never'`);
+    }
+    return s;
+}
+exports.parseUseSudo = parseUseSudo;
 // ((recent "7.9") (stable "7.9"))
 const versionRe = /\(stable "([^"]+)"\)/;
 function lookupStableVersion() {

--- a/lib/setup-racket.js
+++ b/lib/setup-racket.js
@@ -30,8 +30,9 @@ const common = __importStar(require("./common"));
             const distribution = common.parseDistribution(core.getInput('distribution') || 'full');
             const variant = common.parseVariant(core.getInput('variant') || 'regular');
             const dest = core.getInput('dest');
+            const useSudo = common.parseUseSudo(core.getInput('sudo') || '');
             yield core.group(`Installing Racket ${version} (${variant}, ${distribution}, ${arch})...`, () => __awaiter(this, void 0, void 0, function* () {
-                return yield common.install(version, arch, distribution, variant, dest);
+                return yield common.install(version, arch, distribution, variant, dest, useSudo);
             }));
             const catalogs = core.getInput('catalogs', { required: false });
             if (catalogs.trim() !== '') {

--- a/src/common.ts
+++ b/src/common.ts
@@ -89,7 +89,10 @@ async function installLinux(path: string, dest: string, useSudo: UseSudo) {
 
   let launchScript = 'sh /tmp/install-racket.impl.sh';
   if (useSudo == 'always') {
-    await fs.promises.writeFile('/tmp/install-racket.sh', `sudo ${launchScript}\n`);
+    await fs.promises.writeFile(
+      '/tmp/install-racket.sh',
+      `sudo ${launchScript}\n`
+    );
   } else if (useSudo == 'never') {
     await fs.promises.writeFile('/tmp/install-racket.sh', `${launchScript}\n`);
   } else {

--- a/src/setup-racket.ts
+++ b/src/setup-racket.ts
@@ -20,7 +20,14 @@ import * as common from './common';
     await core.group(
       `Installing Racket ${version} (${variant}, ${distribution}, ${arch})...`,
       async () => {
-        return await common.install(version, arch, distribution, variant, dest, useSudo);
+        return await common.install(
+          version,
+          arch,
+          distribution,
+          variant,
+          dest,
+          useSudo
+        );
       }
     );
 

--- a/src/setup-racket.ts
+++ b/src/setup-racket.ts
@@ -16,10 +16,11 @@ import * as common from './common';
     );
     const variant = common.parseVariant(core.getInput('variant') || 'regular');
     const dest = core.getInput('dest');
+    const useSudo = common.parseUseSudo(core.getInput('sudo') || '');
     await core.group(
       `Installing Racket ${version} (${variant}, ${distribution}, ${arch})...`,
       async () => {
-        return await common.install(version, arch, distribution, variant, dest);
+        return await common.install(version, arch, distribution, variant, dest, useSudo);
       }
     );
 


### PR DESCRIPTION
This PR adds the option `sudo: always` and `sudo: never` for always running with/without `sudo`.

More context:
When using a non-unix style installation, it is not necessary to run the installer with sudo. This can simplify later steps in the CI that touch packages in the main distribution. For example, the `sudo` commands can be removed here: <https://github.com/shhyou/typed-racket/commit/382c068e847c75ebccf57ad22b3b0d35ee37b8ca>
