### PR TITLE
Use download.racket-lang.org

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -47,7 +47,7 @@ export function makeInstallerURL(
   const racketPlatform = RACKET_PLATFORMS[platform];
   const racketExt = RACKET_EXTS[platform];
 
-  let base = `https://mirror.racket-lang.org/installers/${version}`;
+  let base = `https://download.racket-lang.org/installers/${version}`;
   const prefix = distribution === 'minimal' ? 'racket-minimal' : 'racket';
   let maybeOS = '';
   let maybeSuffix = variant === 'CS' ? '-cs' : '';


### PR DESCRIPTION
mirror.racket-lang.org is down and long-term we should be using download.racket-lang.org